### PR TITLE
Add initial .gitignore - initially ignoring MacOS metadata fies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# MacOS metadata
+.DS_Store


### PR DESCRIPTION
Added initial .gitignore to the repository. Currently it is ignoring MacOS metadata files (.DS_Store).